### PR TITLE
fix: Define grace_period_hours to prevent NameError

### DIFF
--- a/app_utils.py
+++ b/app_utils.py
@@ -15,6 +15,8 @@ import telegram
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 import calendar
 
+grace_period_hours = 1
+
 # --- Character Dataclass and Global List ---
 
 @dataclass


### PR DESCRIPTION
In `app_utils.py`, the `process_character_wallet` function used the variable `grace_period_hours` without it being defined, causing a `NameError` in the `poll_wallet` Celery task.

This change defines `grace_period_hours` as a global constant at the top of `app_utils.py` with a value of 1. This resolves the error and provides a sensible default grace period to prevent notification spam after a character's history is first imported.