### PR TITLE
fix(attributes): Standardize notification attribute names to plural form

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -804,8 +804,8 @@ async def _show_notification_settings(update: Update, context: ContextTypes.DEFA
 
     keyboard = [
         [InlineKeyboardButton(f"Sales Notifications: {'✅ On' if character.enable_sales_notifications else '❌ Off'}", callback_data=f"toggle_sales_{character.id}")],
-        [InlineKeyboardButton(f"Buy Notifications: {'✅ On' if character.enable_buy_notifications else '❌ Off'}", callback_data=f"toggle_buys_{character.id}")],
-        [InlineKeyboardButton(f"Contract Notifications: {'✅ On' if character.enable_contract_notifications else '❌ Off'}", callback_data=f"toggle_contracts_{character.id}")],
+        [InlineKeyboardButton(f"Buy Notifications: {'✅ On' if character.enable_buys_notifications else '❌ Off'}", callback_data=f"toggle_buys_{character.id}")],
+        [InlineKeyboardButton(f"Contract Notifications: {'✅ On' if character.enable_contracts_notifications else '❌ Off'}", callback_data=f"toggle_contracts_{character.id}")],
         [InlineKeyboardButton(f"Daily Overview: {'✅ On' if character.enable_daily_overview else '❌ Off'}", callback_data=f"toggle_overview_{character.id}")],
         [InlineKeyboardButton(f"Undercut Notifications: {'✅ On' if character.enable_undercut_notifications else '❌ Off'}", callback_data=f"toggle_undercut_{character.id}")],
         [InlineKeyboardButton("« Back", callback_data=back_callback)]


### PR DESCRIPTION
Resolves an `AttributeError` caused by a mismatch between dynamically generated attribute names in `bot.py` and the `Character` dataclass definition in `app_utils.py`.

The callback handler in `bot.py` created attribute names like `enable_buys_notifications`, while the `Character` class used the singular form `enable_buy_notifications`.

This commit standardizes on the plural form across the codebase:
- Renamed attributes in the `Character` dataclass to `enable_buys_notifications` and `enable_contracts_notifications`.
- Updated all related database functions (`load_characters_from_db`, `get_character_by_id`, etc.) to use the new plural names.
- Added a database migration in `setup_database` to rename the `enable_buy_notifications` and `enable_contract_notifications` columns to their plural forms, ensuring data preservation.
- Updated the `_show_notification_settings` function in `bot.py` to use the new plural attribute names, ensuring the UI is consistent with the backend.