### PR TITLE
fix: Correct typo in contract notification setting

### DIFF
--- a/app_utils.py
+++ b/app_utils.py
@@ -2917,7 +2917,7 @@ def process_character_contracts(character_id: int) -> list[dict]:
     Processes contracts for a single character and returns notifications.
     """
     character = get_character_by_id(character_id)
-    if not character or not character.enable_contract_notifications:
+    if not character or not character.enable_contracts_notifications:
         return []
 
     notifications = []


### PR DESCRIPTION
This commit fixes an AttributeError that occurred in the `process_character_contracts` function.

The function was incorrectly trying to access `character.enable_contract_notifications` instead of the correct attribute `character.enable_contracts_notifications`. This typo prevented the contract polling task from running successfully.